### PR TITLE
fatfs: enable writing functions

### DIFF
--- a/fatfs/ffconf.h
+++ b/fatfs/ffconf.h
@@ -12,7 +12,7 @@
 / Function Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_READONLY  1
+#define FF_FS_READONLY  0
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()


### PR DESCRIPTION
This PR enables the writing function.
This change will allow mkdir, rm, create, etc. to work in drivers/examples/sdcard/tinyfs.

https://github.com/tinygo-org/drivers/tree/dev/examples/sdcard/tinyfs