### PR TITLE
Adding `io/fs` package support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ fmt-check:
 	@unformatted=$$(gofmt -l $(FMT_PATHS)); [ -z "$$unformatted" ] && exit 0; echo "Unformatted:"; for fn in $$unformatted; do echo "  $$fn"; done; exit 1
 
 smoke-test:
+	go run ./examples/simple-fatfs
 	@mkdir -p build
 	tinygo build -size short -o ./build/test.hex -target=itsybitsy-m0 ./examples/simple-fatfs/
 	@md5sum ./build/test.hex

--- a/fs.go
+++ b/fs.go
@@ -1,0 +1,20 @@
+package tinyfs
+
+import (
+	"io/fs"
+)
+
+func NewTinyFS(filesystem Filesystem) fs.FS {
+	return &fsWrapper{fs: filesystem}
+}
+
+type fsWrapper struct {
+	fs Filesystem
+}
+
+func (w *fsWrapper) Open(name string) (f fs.File, err error) {
+	return w.fs.Open(name)
+}
+
+// type assertion to ensure tinyfs.File satisfies fs.File
+var _ fs.File = (File)(nil)

--- a/littlefs/go_lfs_test.go
+++ b/littlefs/go_lfs_test.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 package littlefs
 
 import (

--- a/tinyfs.go
+++ b/tinyfs.go
@@ -25,6 +25,7 @@ type File interface {
 	FileHandle
 	IsDir() bool
 	Readdir(n int) (infos []os.FileInfo, err error)
+	Stat() (info os.FileInfo, err error)
 }
 
 // FileHandle is a copy of the experimental os.FileHandle interface in TinyGo


### PR DESCRIPTION
https://github.com/tinygo-org/tinyfs/issues/6

The changes in this PR add compatibility support for the `io/fs` package.  Currently only basic fs.FS support is included.  Will include ReadDir* support as well in a separate PR